### PR TITLE
Add automatic remote branch cleanup after successful ship

### DIFF
--- a/adws/adw_ship_iso.py
+++ b/adws/adw_ship_iso.py
@@ -303,6 +303,7 @@ def main():
 
     # Step 6: Automatic cleanup after successful ship
     repo_root = get_main_repo_root()
+    worktree_path = state.get("worktree_path")
     cleanup_messages = []
 
     # 6a. Delete remote branch
@@ -322,24 +323,6 @@ def main():
         logger.warning(f"⚠️ Failed to delete remote branch: {e}")
         cleanup_messages.append(f"⚠️ Remote branch deletion failed (not critical)")
 
-    # 6b. Clean up worktree
-    logger.info(f"Cleaning up: Removing worktree for {adw_id}...")
-    try:
-        purge_script = os.path.join(repo_root, "scripts", "purge_tree.sh")
-        result = subprocess.run(
-            [purge_script, adw_id],
-            capture_output=True, text=True, cwd=repo_root
-        )
-        if result.returncode == 0:
-            logger.info(f"✅ Cleaned up worktree: {adw_id}")
-            cleanup_messages.append(f"✅ Cleaned up worktree `trees/{adw_id}/`")
-        else:
-            logger.warning(f"⚠️ Failed to clean worktree: {result.stderr}")
-            cleanup_messages.append(f"⚠️ Worktree cleanup failed (not critical)")
-    except Exception as e:
-        logger.warning(f"⚠️ Failed to clean worktree: {e}")
-        cleanup_messages.append(f"⚠️ Worktree cleanup failed (not critical)")
-
     # Post cleanup status
     if cleanup_messages:
         cleanup_status = "\n".join(cleanup_messages)
@@ -347,7 +330,9 @@ def main():
             issue_number,
             format_issue_message(adw_id, AGENT_SHIPPER,
                                f"🧹 **Automatic cleanup:**\n\n{cleanup_status}\n\n"
-                               f"📝 Logs preserved in `agents/{adw_id}/`")
+                               f"📂 Worktree preserved at `{worktree_path}` for debugging\n"
+                               f"📝 Logs preserved in `agents/{adw_id}/`\n\n"
+                               f"To clean up worktree: `./scripts/purge_tree.sh {adw_id}`")
         )
         logger.info("Automatic cleanup completed")
 


### PR DESCRIPTION
# Automatic Remote Branch Cleanup

Adds automatic cleanup of remote branches after successful SHIP phase in the ZTE workflow.

## Summary

After a successful merge to main, the workflow now automatically deletes the remote feature branch to keep the repository clean, following GitHub best practices.

## Changes

### Modified: `adws/adw_ship_iso.py`

**Cleanup strategy:**
- ✅ **DELETE**: Remote branch (via `git push origin --delete`)
- ✅ **PRESERVE**: Worktree in `trees/<adw-id>/` for post-deploy debugging
- ✅ **PRESERVE**: Logs in `agents/<adw-id>/`

### Behavior After Successful Ship

The workflow will:
1. Merge branch to main
2. Push to origin/main
3. **Automatically delete remote branch**
4. Post cleanup status to issue
5. Provide manual cleanup command for worktree

### Issue Comment Example

```
🧹 Automatic cleanup:

✅ Deleted remote branch `bug-issue-33-adw-xxx-fix-spacing`

📂 Worktree preserved at `trees/xxx/` for debugging
📝 Logs preserved in `agents/xxx/`

To clean up worktree: ./scripts/purge_tree.sh xxx
```

## Benefits

1. **Clean Repository**: No accumulation of merged feature branches
2. **GitHub Best Practice**: Following suggested workflow (delete branch after merge)
3. **Recoverable**: Branch can be restored from PR if needed
4. **Manual Control**: Worktree cleanup remains manual for debugging flexibility

## Testing

Tested with issue #33:
- ✅ Remote branch deleted successfully
- ✅ Worktree preserved for debugging
- ✅ Logs preserved
- ✅ Comment posted to issue

## Trade-offs

**Automatic:**
- Remote branch deletion (small, easily recoverable)

**Manual:**
- Worktree cleanup (large, useful for debugging)
- Can use `./scripts/purge_tree.sh <adw-id>` when ready

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)